### PR TITLE
font isnt readable when capital 'i' vs capital 'l'

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -65,7 +65,7 @@ const IndexPage = ({ data }) => {
       <Table striped bordered hover>
         <thead>
           <tr>
-            <th>Code</th>
+            <th style="{{font-family: Tahoma}}" >Code</th>
             <th>Description</th>
             <th>Expires</th>
             <th>Date Added</th>


### PR DESCRIPTION
Tahoma font makes it easier to distinguish a captial I vs a captial L